### PR TITLE
Fix bug in `open_mediaLink`

### DIFF
--- a/SlideNav.py
+++ b/SlideNav.py
@@ -746,7 +746,7 @@ class Commands ():
 
 			#═════      • • •   Set MediaLink FilePath      ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════⌠¦•••s1⌡#
 
-		filePath_Region = sublime.Region ( mediaLink_PathLine.a + fileStart_Offset + whitespaceOffset, mediaLink_PathLine.b - fileEnd_Offset )
+		filePath_Region = sublime.Region ( mediaLink_PathLine.a + fileStart_Offset + whitespaceOffset, mediaLink_PathLine.b - mediaLink_RightOffset )
 		nextLine_Region = sublime.Region ( mediaLink_PathLine.b + 1, mediaLink_PathLine.b + 1 )
 		filePath        = view.substr ( filePath_Region )
 		filePath_Length = len ( filePath )


### PR DESCRIPTION
I add a bug where the following medial link wasn't working:

```
#□ Star Wars □#
    #@ star_wars.jpg □#
```

To make it work I had to change it to:

```
#□ Star Wars □#
    #@ star_wars.jpg □
```

It appears it was an issue in `open_MediaLink` which wasn't correctly cutting the path.
